### PR TITLE
Auth/server version

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -88,8 +88,8 @@ func (as *Server) HandleLoginRequest(w http.ResponseWriter, r *http.Request) {
 	// otherwise, check the 'IsNewUser' flag from the request
 
 	var isNewUser bool
-	reqServerVersion := lrb.ServerVersion
-	if reqServerVersion != as.serverVersion {
+	requestServerVersion := lrb.ServerVersion
+	if requestServerVersion != as.serverVersion {
 		isNewUser = true
 	} else {
 		isNewUser = lrb.IsNewUser


### PR DESCRIPTION
- auth server now maintains a server version (timestamp of when the current server instance was created)
- client sends its known server version in the login request, which is used by the server to determine if the player is new (server version mismatch) before even checking the "isNewUser" flag in the request
- server sends back its version in the login response, so that the client can then save it